### PR TITLE
one frame per connection

### DIFF
--- a/sql12/core/src/net/sourceforge/squirrel_sql/client/gui/desktopcontainer/docktabdesktop/DesktopTabbedPane.java
+++ b/sql12/core/src/net/sourceforge/squirrel_sql/client/gui/desktopcontainer/docktabdesktop/DesktopTabbedPane.java
@@ -1,9 +1,9 @@
 package net.sourceforge.squirrel_sql.client.gui.desktopcontainer.docktabdesktop;
 
-import java.awt.Component;
-import java.awt.Dimension;
+import java.awt.*;
 import java.awt.event.MouseEvent;
-import javax.swing.Icon;
+import javax.swing.*;
+import javax.swing.plaf.metal.MetalTabbedPaneUI;
 
 import net.sourceforge.squirrel_sql.client.IApplication;
 import net.sourceforge.squirrel_sql.client.gui.builders.dndtabbedpane.DnDTabbedPane;
@@ -13,13 +13,32 @@ import net.sourceforge.squirrel_sql.fw.gui.buttontabcomponent.SmallTabButton;
 
 public class DesktopTabbedPane extends DnDTabbedPane
 {
+    boolean _hideTabBar = false;
+    JLabel _titleLabel;
+
    public DesktopTabbedPane(IApplication app)
    {
       super(app.getMultipleWindowsHandler().getOutwardDndTabbedPaneChanel());
+      _hideTabBar = app.getSquirrelPreferences().getUseNewFramePerConnection();
       setPaintScrollArea(false);
       setPaintGhost(true);
-
-      GUIUtils.listenToMouseWheelClickOnTab(this, (tabIndex, tabComponent) -> ((ButtonTabComponent)tabComponent).doClickClose());
+       setUI(new MetalTabbedPaneUI() {
+           @Override
+           protected void paintContentBorder(Graphics g, int tabPlacement, int selectedIndex) {
+               if (!_hideTabBar) {
+                   super.paintContentBorder(g, tabPlacement, selectedIndex);
+               }
+           }
+           @Override
+           protected int calculateTabAreaHeight(int tab_placement, int run_count, int max_tab_height) {
+               if (_hideTabBar && DesktopTabbedPane.this.getTabCount() <= 1) {
+                   return 0;
+               } else {
+                   return super.calculateTabAreaHeight(tab_placement, run_count, max_tab_height);
+               }
+           }
+       });
+       GUIUtils.listenToMouseWheelClickOnTab(this, (tabIndex, tabComponent) -> ((ButtonTabComponent)tabComponent).doClickClose());
    }
 
 
@@ -40,6 +59,7 @@ public class DesktopTabbedPane extends DnDTabbedPane
    {
       ButtonTabComponent btc = (ButtonTabComponent) getTabComponentAt(index);
       btc.setTitle(title);
+      _titleLabel.setText(title.replaceAll("^[0-9]* - ", ""));
    }
 
    @Override

--- a/sql12/core/src/net/sourceforge/squirrel_sql/client/gui/desktopcontainer/docktabdesktop/TabWindowController.java
+++ b/sql12/core/src/net/sourceforge/squirrel_sql/client/gui/desktopcontainer/docktabdesktop/TabWindowController.java
@@ -35,13 +35,16 @@ public class TabWindowController implements DockTabDesktopPaneHolder
    private IApplication _app;
    private final JMenu _mnuSession;
    private final JFrame _tabWindowFrame;
+   String _title;
 
    private static class MoveTabBackToMainWinMarker {}
 
-   public TabWindowController(Point locationOnScreen, Dimension size, final IApplication app)
+   public TabWindowController(String title, Point locationOnScreen, Dimension size, final IApplication app)
    {
+       // Kind of a hack, would be better if the title code was refactored
+       _title = title.replaceAll("^[0-9]* - ", "");
       _app = app;
-      _tabWindowFrame = new JFrame(_app.getMainFrame().getTitle() + " " +s_stringMgr.getString("docktabdesktop.TabWindowController.titlePostFix"));
+      _tabWindowFrame = new JFrame(title);
 
       _tabWindowFrame.setLocation(locationOnScreen);
       _tabWindowFrame.setSize(size);

--- a/sql12/core/src/net/sourceforge/squirrel_sql/client/preferences/GeneralPreferencesGUI.java
+++ b/sql12/core/src/net/sourceforge/squirrel_sql/client/preferences/GeneralPreferencesGUI.java
@@ -28,7 +28,8 @@ final class GeneralPreferencesGUI extends JPanel
    private static final StringManager s_stringMgr = StringManagerFactory.getStringManager(GeneralPreferencesGUI.class);
 
    private JRadioButton _tabbedStyle = new JRadioButton(s_stringMgr.getString("GeneralPreferencesPanel.tabbedStyle"));
-   private JRadioButton _internalFrameStyle = new JRadioButton(s_stringMgr.getString("GeneralPreferencesPanel.internalFrameStyle"));
+    private JRadioButton _internalFrameStyle = new JRadioButton(s_stringMgr.getString("GeneralPreferencesPanel.internalFrameStyle"));
+   private JRadioButton _useNewFramePerConnection = new JRadioButton(s_stringMgr.getString("GeneralPreferencesPanel.useNewFramePerConnection"));
    private JCheckBox _useScrollableTabbedPanesForSessionTabs = new JCheckBox(s_stringMgr.getString("GeneralPreferencesPanel.useScrollableTabbedPanesForSessionTabs"));
    private JCheckBox _showContents = new JCheckBox(s_stringMgr.getString("GeneralPreferencesPanel.showwindowcontents"));
    private JCheckBox _maximimizeSessionSheet = new JCheckBox(s_stringMgr.getString("GeneralPreferencesPanel.maxonopen"));
@@ -82,9 +83,18 @@ final class GeneralPreferencesGUI extends JPanel
 
    void loadData(SquirrelPreferences prefs)
    {
-      _tabbedStyle.setSelected(prefs.getTabbedStyle());
+       if (prefs.getUseNewFramePerConnection())
+       {
+           _useNewFramePerConnection.setSelected(true);
+           _tabbedStyle.setSelected(false);
+           _internalFrameStyle.setSelected(false);
+       }
+       else {
+           _tabbedStyle.setSelected(prefs.getTabbedStyle());
+           _internalFrameStyle.setSelected(!prefs.getTabbedStyle());
+           _useNewFramePerConnection.setSelected(false);
+       }
       _useScrollableTabbedPanesForSessionTabs.setSelected(prefs.getUseScrollableTabbedPanesForSessionTabs());
-      _internalFrameStyle.setSelected(!prefs.getTabbedStyle());
       onStyleChanged();
       _showTabbedStyleHint.setSelected(prefs.getShowTabbedStyleHint());
 
@@ -122,8 +132,8 @@ final class GeneralPreferencesGUI extends JPanel
       LocaleWrapper.setSelectedLocalePrefsString(_localeChooser, prefs.getPreferredLocale());
 
       _tabbedStyle.addActionListener(e -> onStyleChanged());
-
       _internalFrameStyle.addActionListener(e -> onStyleChanged());
+      _useNewFramePerConnection.addActionListener(e -> onStyleChanged());
 
       _messagePrefsCtrl.loadData(prefs);
 
@@ -142,7 +152,13 @@ final class GeneralPreferencesGUI extends JPanel
 
    void applyChanges(SquirrelPreferences prefs)
    {
-      prefs.setTabbedStyle(_tabbedStyle.isSelected());
+       if (_useNewFramePerConnection.isSelected()) {
+           prefs.setUseNewFramePerConnection(true);
+           prefs.setTabbedStyle(true);
+       } else {
+           prefs.setUseNewFramePerConnection(false);
+           prefs.setTabbedStyle(_tabbedStyle.isSelected());
+       }
       prefs.setUseScrollableTabbedPanesForSessionTabs(_useScrollableTabbedPanesForSessionTabs.isSelected());
       prefs.setShowContentsWhenDragging(_showContents.isSelected());
       prefs.setShowTabbedStyleHint(_showTabbedStyleHint.isSelected());
@@ -211,6 +227,7 @@ final class GeneralPreferencesGUI extends JPanel
 
       g.add(_tabbedStyle);
       g.add(_internalFrameStyle);
+      g.add(_useNewFramePerConnection);
       final GridBagConstraints gbc = new GridBagConstraints();
       gbc.fill = GridBagConstraints.HORIZONTAL;
       gbc.insets = new Insets(2, 4, 2, 4);
@@ -224,6 +241,9 @@ final class GeneralPreferencesGUI extends JPanel
       ++gbc.gridy;
       _internalFrameStyle.setName("internalFrameStyleRadioButton");
       pnl.add(_internalFrameStyle, gbc);
+      ++gbc.gridy;
+      _useNewFramePerConnection.setName("useNewFramePerConnectionRadioButton");
+      pnl.add(_useNewFramePerConnection, gbc);
       ++gbc.gridy;
 
       _useScrollableTabbedPanesForSessionTabs.setName("useScrollableTabbedPanes");

--- a/sql12/core/src/net/sourceforge/squirrel_sql/client/preferences/I18NStrings.properties
+++ b/sql12/core/src/net/sourceforge/squirrel_sql/client/preferences/I18NStrings.properties
@@ -132,6 +132,7 @@ GeneralPreferencesPanel.tabbedStyle=Use tabbed layout (needs restart)
 GeneralPreferencesPanel.useScrollableTabbedPanesForSessionTabs=Use scrollable tabbed panes for Session tabs (needs restart) 
 GeneralPreferencesPanel.internalFrameStyle=Use MDI/Internal Frame layout (needs restart)
 GeneralPreferencesPanel.showTabbedStyleHint=Warn MDI/Internal Frame layout is deprecated
+GeneralPreferencesPanel.useNewFramePerConnection=Use new Frame per connection (needs restart)
 
 GeneralPreferencesPanel.savePreferencesImmediatelyWarning_new=Warning:\nSaving Aliases and Drivers immediately may significantly slow down\nediting Aliases and Drivers if many Aliases or Drivers exist.\nSaving Preferences immediately may significantly slow down SQL execution\nif multiple statements are executed or if SQL history size is big\n(see menu 'New Session Properties' --> tab 'SQL' --> SQL History).
 

--- a/sql12/core/src/net/sourceforge/squirrel_sql/client/preferences/SquirrelPreferences.java
+++ b/sql12/core/src/net/sourceforge/squirrel_sql/client/preferences/SquirrelPreferences.java
@@ -86,6 +86,7 @@ public class SquirrelPreferences implements Serializable
       String SHOW_ALIASES_TOOL_BAR = "showAliasesToolBar";
       String SHOW_CONTENTS_WHEN_DRAGGING = "showContentsWhenDragging";
       String TABBED_STYLE = "tabbedStyle";
+      String USE_NEW_FRAME_PER_CONNECTION = "useNewFramePerConnection";
       String USE_SCROLLABLE_TABBED_PANES_FOR_SESSION_TABS = "useScrollableTabbedPanesForSessionTabs";
       String SHOW_TABBED_STYLE_HINT = "showTabbedStyleHint";
       String SHOW_DRIVERS_TOOL_BAR = "showDriversToolBar";
@@ -187,6 +188,8 @@ public class SquirrelPreferences implements Serializable
 
 
    private boolean _tabbedStyle = true;
+
+   private boolean _useNewFramePerConnection = false;
 
    private boolean _useScrollableTabbedPanesForSessionTabs;
 
@@ -424,7 +427,12 @@ public class SquirrelPreferences implements Serializable
 		return _tabbedStyle;
 	}
 
-	public synchronized void setTabbedStyle(boolean data)
+    public boolean getUseNewFramePerConnection()
+    {
+        return _useNewFramePerConnection;
+    }
+
+    public synchronized void setTabbedStyle(boolean data)
 	{
 		if (data != _tabbedStyle)
 		{
@@ -434,6 +442,17 @@ public class SquirrelPreferences implements Serializable
 												oldValue, _tabbedStyle);
 		}
 	}
+
+    public synchronized void setUseNewFramePerConnection(boolean data)
+    {
+        if (data != _useNewFramePerConnection)
+        {
+            final boolean oldValue = _useNewFramePerConnection;
+            _useNewFramePerConnection = data;
+            getPropertyChangeReporter().firePropertyChange(IPropertyNames.USE_NEW_FRAME_PER_CONNECTION,
+                    oldValue, _useNewFramePerConnection);
+        }
+    }
 
    public boolean getUseScrollableTabbedPanesForSessionTabs()
    {

--- a/sql12/core/src/net/sourceforge/squirrel_sql/client/preferences/SquirrelPreferencesBeanInfo.java
+++ b/sql12/core/src/net/sourceforge/squirrel_sql/client/preferences/SquirrelPreferencesBeanInfo.java
@@ -50,6 +50,7 @@ public class SquirrelPreferencesBeanInfo extends SimpleBeanInfo implements Squir
             prop(SHOW_CONTENTS_WHEN_DRAGGING, SquirrelPreferences.class, "getShowContentsWhenDragging", "setShowContentsWhenDragging"),
 
             prop(TABBED_STYLE, SquirrelPreferences.class, "getTabbedStyle", "setTabbedStyle"),
+            prop(USE_NEW_FRAME_PER_CONNECTION, SquirrelPreferences.class, "getUseNewFramePerConnection", "setUseNewFramePerConnection"),
             prop(USE_SCROLLABLE_TABBED_PANES_FOR_SESSION_TABS, SquirrelPreferences.class, "getUseScrollableTabbedPanesForSessionTabs", "setUseScrollableTabbedPanesForSessionTabs"),
             prop(SHOW_TABBED_STYLE_HINT, SquirrelPreferences.class, "getShowTabbedStyleHint", "setShowTabbedStyleHint"),
 


### PR DESCRIPTION
Earlier in the year, I opened this request...
https://sourceforge.net/p/squirrel-sql/feature-requests/619/

A quick recap...
It is my belief that the future will be tiling window managers, and instead of each app having its own tab mechanism, your window manager will implement a grand unified tabbing scheme.

With this in mind, I had a few requests, one is that the title bar reflected the database opened. And secondly that squirrel implemented one frame per connection enforced as an optional feature.

Gerd Wagner very kindly implemented the title bar update mechanism, however as it happens, it doesn't help me, because it's only implemented for the main window, and not when tabs are detached into external windows. I don't think he was interested in the one frame per connection model, which is understandable, so that's what this pull request is about. It does the following:

1. has a new General Preference - Use new Frame per connection. 
2. when the above is selected, new tabs on the main frame are forcibly ejected onto a new Frame.
3. Not wanting tabs on the new Frame, when the option is turned on, tabs are disabled. (The mechanism is a bit of a kludge... the tab bar height is set to zero, and I interfere with the painting to effectively make the tab bar invisible. I then add a centered title to show the user what the connection is.
4. The title of the new frame is set to the connection name. I did not make this conditional on the option, because this is for sure an oversight of the original implementation that should have accounted for all frames having the correct title. However I did not want to get involved in all that machinery, what I've done here works for me because there won't be multiple tabs when the option is on.

The result of this is every time you click an Alias in the main frame, you get a sub frame for the new connection. If this patch is accepted, or something like it, I would probably make some further suggestions to make the mainframe more useful, because having its main area always blank with everything in the sidebar is weak, but that change could come later.

I'm sure the maintainers here could probably achieve what I did more elegantly, so if they don't like what I've done, feel free to do it another way.