### PR TITLE
Bug fix: "Create Table" script generation dropped "with time zone" from TIMESTAMP/TIME column

### DIFF
--- a/sql12/core/src/net/sourceforge/squirrel_sql/fw/dialects/CommonHibernateDialect.java
+++ b/sql12/core/src/net/sourceforge/squirrel_sql/fw/dialects/CommonHibernateDialect.java
@@ -31,6 +31,7 @@ import net.sourceforge.squirrel_sql.fw.sql.ITableInfo;
 import net.sourceforge.squirrel_sql.fw.sql.SQLUtilities;
 import net.sourceforge.squirrel_sql.fw.sql.TableColumnInfo;
 import org.antlr.stringtemplate.StringTemplate;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A base class for dialects where the most frequently implemented behavior can located, to avoid code
@@ -582,7 +583,46 @@ public abstract class CommonHibernateDialect implements HibernateDialect, String
 			dataType = getJavaTypeForNativeType(tcInfo.getTypeName());
 		}
 
-		return getTypeName(dataType, columnSize, precision, tcInfo.getDecimalDigits(), tcInfo.getTypeName());
+		String typeName = getTypeName(dataType, columnSize, precision, tcInfo.getDecimalDigits(), tcInfo.getTypeName());
+		return appendTimeZoneQualifierIfNeeded(dataType, tcInfo.getTypeName(), typeName);
+	}
+
+	/**
+	 * java.sql.Types.TIMESTAMP/TIME don't distinguish the plain and "with time zone" variants, so a
+	 * dialect's registered type name (e.g. "timestamp") silently drops the qualifier even though the
+	 * driver's real TYPE_NAME (e.g. Postgres "timestamptz") indicates it. Restore the qualifier here,
+	 * once, for every dialect, instead of duplicating this check in each *DialectExt subclass.
+	 */
+	private String appendTimeZoneQualifierIfNeeded(int dataType, String driverTypeNameOrNull, String resolvedTypeName)
+	{
+		if (driverTypeNameOrNull == null || resolvedTypeName == null)
+		{
+			return resolvedTypeName;
+		}
+
+		boolean isTimestampFamily = dataType == Types.TIMESTAMP || dataType == Types.TIMESTAMP_WITH_TIMEZONE;
+		boolean isTimeFamily = dataType == Types.TIME || dataType == Types.TIME_WITH_TIMEZONE;
+		if (!isTimestampFamily && !isTimeFamily)
+		{
+			return resolvedTypeName;
+		}
+
+		if (StringUtils.containsIgnoreCase(resolvedTypeName, "with time zone"))
+		{
+			// Some dialects (e.g. Oracle's raw TYPE_NAME fallback) already include the qualifier.
+			return resolvedTypeName;
+		}
+
+		boolean driverIndicatesTimeZone = StringUtils.equalsIgnoreCase(driverTypeNameOrNull, "timestamptz")
+			|| StringUtils.equalsIgnoreCase(driverTypeNameOrNull, "timetz")
+			|| StringUtils.containsIgnoreCase(driverTypeNameOrNull, "with time zone");
+
+		if (driverIndicatesTimeZone)
+		{
+			return resolvedTypeName + " with time zone";
+		}
+
+		return resolvedTypeName;
 	}
 
 	/**


### PR DESCRIPTION
Problem

  When generating a "Create Table" DDL script for an existing table (right-click table → Scripts → Create), SQuirreL emitted timestamp instead of timestamp with time zone for PostgreSQL
  columns that actually have a timezone (timestamptz). The same applied to time/timetz.

  Root cause

  java.sql.Types.TIMESTAMP and Types.TIME don't distinguish the plain and "with time zone" variants. Every dialect registers a flat mapping (e.g. PostgreSQLDialectExt:
  registerColumnType(Types.TIMESTAMP, "timestamp")), so the qualifier is silently dropped — even though it is present in the driver's real JDBC TYPE_NAME (e.g. Postgres reports
  timestamptz/timetz).

  Fix

  Added one shared post-processing step in CommonHibernateDialect.getTypeName(TableColumnInfo) — the single chokepoint used by every dialect for both "Create Table" and "Alter Column Type"
  DDL generation. After resolving the base type name, it checks the driver's raw TYPE_NAME for a timezone indicator (timestamptz, timetz, or a "with time zone" substring) and appends " with 
  time zone" if the resolved name doesn't already have it.

  This is a shared fix rather than a Postgres-only patch, so it also covers other ANSI-timezone-capable dialects (H2, HSQLDB, Derby, Firebird, etc.) that inherit getTypeName(TableColumnInfo)
  from CommonHibernateDialect without requiring any per-dialect changes.

  File changed: sql12/core/src/net/sourceforge/squirrel_sql/fw/dialects/CommonHibernateDialect.java (+41/-1)

  Testing
  - Manually verified

Note: Used Sonnet 5 for development of the fix